### PR TITLE
Fixed #11772: Expression manager convert_value does not obey strict setting

### DIFF
--- a/application/helpers/expressions/em_core_helper.php
+++ b/application/helpers/expressions/em_core_helper.php
@@ -2714,7 +2714,7 @@ function exprmgr_convert_value($fValueToReplace, $iStrict, $sTranslateFromList, 
                     $iNearestIndex = $i;
                 }
             }
-            if ( $iStrict !== 1 ) {
+            if ( $iStrict != 1 ) {  // Do not use strict checking as the parameter will be passed as a string!
                 return $aToValues[$iNearestIndex];
             }
         }


### PR DESCRIPTION
https://bugs.limesurvey.org/view.php?id=11772

Javascript evaluation works, backend evaluation does not. See attached survey in bugtracker for details.

Please also port to the 2.06lts branch when accepting.
